### PR TITLE
Potential fix of #49

### DIFF
--- a/R/read.gatingML.cytobank.R
+++ b/R/read.gatingML.cytobank.R
@@ -72,7 +72,7 @@ read.gatingML.cytobank <- function(file, ...){
 
   #construct tree from GateSets
   g <- constructTree(flowEnv, gateInfo)
-
+  
   #determine comps and trans to be used
 
   comp_refs <- gateInfo[, comp_ref]
@@ -359,8 +359,14 @@ addGate <- function(gateInfo,flowEnv, g, popId, gateID){
   #add gate
   sb <- gateInfo[id == gateID, ]
   nGates <- nrow(sb)
-  if(nGates > 1)
-    stop("multiple gates found for ", gateID)
+  if(nGates > 1){
+    uncomp.ind <- grep("uncompensated", sb$comp_ref) 
+    if(length(uncomp.ind) == 1){
+      sb<- sb[-uncomp.ind,]
+    } else{
+      stop("multiple gates found for ", gateID)
+    }
+  }
   #try to find the tailored gate
   tg_sb <- gateInfo[gate_id == sb[, gate_id] & fcs != "", ]
 


### PR DESCRIPTION
Addresses issue #49 
If a gate is defined on one compensated and one uncompensated axis (i.e. scatter + FL channel), addGate only uses the compensated version of the version of the gate. If a gates defined on two compensations and one of them is not "uncompensated" it [appropriately] still returns an error. 

Should probably be covered by a test, but that would require updating the included cytobank gating ML file to include a gate drawn on scatter vs. fluorescence channel. 