### PR TITLE
Update logic of search_for_fcs within FlowJo workspace parser

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ open_workspace <- function(filename, sample_name_location, xmlParserOption) {
     .Call(`_CytoML_open_workspace`, filename, sample_name_location, xmlParserOption)
 }
 
-parse_workspace <- function(ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, fcs_parse_arg, num_threads = 1L) {
-    .Call(`_CytoML_parse_workspace`, ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, fcs_parse_arg, num_threads)
+parse_workspace <- function(ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, greedy_match, fcs_parse_arg, num_threads = 1L) {
+    .Call(`_CytoML_parse_workspace`, ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, greedy_match, fcs_parse_arg, num_threads)
 }
 
 get_keywords_by_id <- function(ws, sample_id) {

--- a/R/flowJoWorkspace_Methods.R
+++ b/R/flowJoWorkspace_Methods.R
@@ -126,6 +126,8 @@ setMethod("parseWorkspace",signature("flowjo_workspace"),function(obj, ...){
 #'          \item keywords.source \code{character} the place where the keywords are extracted from, can be either "XML" or "FCS"
 #'          \item keyword.ignore.case a \code{logical} flag indicates whether the keywords matching needs to be case sensitive.    
 #'          \item include_empty_tree a \code{logical} whether to include samples that don't have gates.
+#'          \item greedy_match \code{logical}: By default, if flowjo_to_gatingset finds multiple FCS files matching a sample by total event count as well as sampleID and/or keywords specified by additional.keys and additional.sampleID, it will return an error listing the duplicate files.
+#'                                            If greedy_match is TRUE, the method will simply take the first file with either filename or $FIL keyword matching the sample name and having the correct number of events.
 #' 			\item transform \code{logical} to enable/disable transformation of gates and data. Default is TRUE. It is mainly for debug purpose (when the raw gates need to be parsed.
 #'      	\item ...: Additional arguments to be passed to \link{read.ncdfFlowSet} or \link{read.flowSet}.
 #'      	}

--- a/R/flowJoWorkspace_Methods.R
+++ b/R/flowJoWorkspace_Methods.R
@@ -188,6 +188,7 @@ flowjo_to_gatingset <- function(ws, name = NULL
     , compensation = NULL
     , transform = TRUE
 	, fcs_file_extension = ".fcs"
+	, greedy_match = FALSE
 	, mc.cores = 1
     , ...)
 {
@@ -268,6 +269,7 @@ flowjo_to_gatingset <- function(ws, name = NULL
                  , comps = compensation
                 , transform = transform
 		 		 , fcs_file_extension = fcs_file_extension
+		 		 , greedy_match = greedy_match
 				 , fcs_parse_arg = args
 		 		 , num_threads = mc.cores
               )

--- a/inst/include/CytoML/flowJoWorkspace.hpp
+++ b/inst/include/CytoML/flowJoWorkspace.hpp
@@ -266,7 +266,7 @@ public:
 			// Note sample_info.total_event_count comes from root node population and so may not agree with $TOT key value for the sample
 			auto tot_it = sample_info.keywords.find("$TOT");
 			if(tot_it == sample_info.keywords.end())
-				throw(domain_error("Sample " + sample_info.sample_name + " does not have value for $TOT in workspace and will be excluded."));
+				throw(domain_error("$TOT keyword not found in workspace for sample " + sample_info.sample_name));
 			int total_event_count = stoi(tot_it->second);
 
 			isfound = search_for_fcs(data_dir, sample_info.sample_id, sample_info.sample_name, total_event_count, ws_key_seq, config_const, frptr);
@@ -529,13 +529,15 @@ public:
 				switch(count(matches_full.begin(), matches_full.end(), true)){ // number that match $TOT AND sampleID + key sequence
 				case 0:
 				{
-					PRINT("No FCS files for sample " + sample_name + " match specified keywords. Sample will be excluded.\n");
+					if(g_loglevel>=GATING_HIERARCHY_LEVEL)
+						PRINT("No FCS files for sample " + sample_name + " match specified keywords. Sample will be excluded.\n");
 					break;
 				}
 				case 1:
 				{
 					int match_final = distance(matches_full.begin(), find(matches_full.begin(), matches_full.end(), true));
 					fr.reset(new MemCytoFrame(file_paths[match_final], fcs_read_param));
+					fr->read_fcs_header();
 					isfound = true;
 					break;
 				}
@@ -547,7 +549,7 @@ public:
 					    candidates += file_paths[i] + "\n"; 
 					throw(domain_error("Multiple FCS files match sample " + sample_name + " by filename, event count, and keywords.\n"
 									   "Candidates are: \n" + candidates +
-									   "Please move incorrect files out of this directory or its subdirectories or this sample will be excluded.\n"));
+									   "Please move incorrect files out of this directory or its subdirectories.\n"));
 				}
 				}
 			}

--- a/inst/include/CytoML/flowJoWorkspace.hpp
+++ b/inst/include/CytoML/flowJoWorkspace.hpp
@@ -262,7 +262,14 @@ public:
 		if(config_const.is_gating)
 		{
 			//match FCS
-			isfound = search_for_fcs(data_dir, sample_info.sample_id, sample_info.sample_name, sample_info.total_event_count, ws_key_seq, config_const, frptr);
+
+			// Note sample_info.total_event_count comes from root node population and so may not agree with $TOT key value for the sample
+			auto tot_it = sample_info.keywords.find("$TOT");
+			if(tot_it == sample_info.keywords.end())
+				throw(domain_error("Sample " + sample_info.sample_name + " does not have value for $TOT in workspace and will be excluded."));
+			int total_event_count = stoi(tot_it->second);
+
+			isfound = search_for_fcs(data_dir, sample_info.sample_id, sample_info.sample_name, total_event_count, ws_key_seq, config_const, frptr);
 			if(!isfound){
 			  PRINT("FCS not found for sample " + uid + " from searching the file extension: " + config_const.fcs_file_extension + "\n");
 			}
@@ -667,6 +674,7 @@ public:
 				if(sample_info.population_count == 0&&!config.include_empty_tree)
 					continue;
 
+				// Note in rare cases this may not agree with $TOT key value for the sample
 				sample_info.total_event_count = get_event_count(getRoot(sample_info.sample_node));
 				//cache sample_name for the same reason
 				sample_info.sample_name = get_sample_name(sample_info.sample_node);

--- a/man/flowjo_to_gatingset.Rd
+++ b/man/flowjo_to_gatingset.Rd
@@ -25,6 +25,7 @@ flowjo_to_gatingset(
   compensation = NULL,
   transform = TRUE,
   fcs_file_extension = ".fcs",
+  greedy_match = FALSE,
   mc.cores = 1,
   ...
 )
@@ -59,6 +60,8 @@ flowjo_to_gatingset(
 \item keywords.source \code{character} the place where the keywords are extracted from, can be either "XML" or "FCS"
 \item keyword.ignore.case a \code{logical} flag indicates whether the keywords matching needs to be case sensitive.    
 \item include_empty_tree a \code{logical} whether to include samples that don't have gates.
+\item greedy_match \code{logical}: By default, if flowjo_to_gatingset finds multiple FCS files matching a sample by total event count as well as sampleID and/or keywords specified by additional.keys and additional.sampleID, it will return an error listing the duplicate files.
+                                  If greedy_match is TRUE, the method will simply take the first file with either filename or $FIL keyword matching the sample name and having the correct number of events.
    \item transform \code{logical} to enable/disable transformation of gates and data. Default is TRUE. It is mainly for debug purpose (when the raw gates need to be parsed.
 \item ...: Additional arguments to be passed to \link{read.ncdfFlowSet} or \link{read.flowSet}.
 }}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -21,8 +21,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // parse_workspace
-XPtr<GatingSet> parse_workspace(XPtr<flowJoWorkspace> ws, int group_id, List subset, bool execute, string path, string h5_dir, bool includeGates, vector<string> additional_keys, bool additional_sampleID, vector<string> keywords, bool is_pheno_data_from_FCS, bool keyword_ignore_case, float extend_val, float extend_to, bool channel_ignore_case, bool leaf_bool, bool include_empty_tree, List comps, bool transform, string fcs_file_extension, FCS_READ_PARAM fcs_parse_arg, int num_threads);
-RcppExport SEXP _CytoML_parse_workspace(SEXP wsSEXP, SEXP group_idSEXP, SEXP subsetSEXP, SEXP executeSEXP, SEXP pathSEXP, SEXP h5_dirSEXP, SEXP includeGatesSEXP, SEXP additional_keysSEXP, SEXP additional_sampleIDSEXP, SEXP keywordsSEXP, SEXP is_pheno_data_from_FCSSEXP, SEXP keyword_ignore_caseSEXP, SEXP extend_valSEXP, SEXP extend_toSEXP, SEXP channel_ignore_caseSEXP, SEXP leaf_boolSEXP, SEXP include_empty_treeSEXP, SEXP compsSEXP, SEXP transformSEXP, SEXP fcs_file_extensionSEXP, SEXP fcs_parse_argSEXP, SEXP num_threadsSEXP) {
+XPtr<GatingSet> parse_workspace(XPtr<flowJoWorkspace> ws, int group_id, List subset, bool execute, string path, string h5_dir, bool includeGates, vector<string> additional_keys, bool additional_sampleID, vector<string> keywords, bool is_pheno_data_from_FCS, bool keyword_ignore_case, float extend_val, float extend_to, bool channel_ignore_case, bool leaf_bool, bool include_empty_tree, List comps, bool transform, string fcs_file_extension, bool greedy_match, FCS_READ_PARAM fcs_parse_arg, int num_threads);
+RcppExport SEXP _CytoML_parse_workspace(SEXP wsSEXP, SEXP group_idSEXP, SEXP subsetSEXP, SEXP executeSEXP, SEXP pathSEXP, SEXP h5_dirSEXP, SEXP includeGatesSEXP, SEXP additional_keysSEXP, SEXP additional_sampleIDSEXP, SEXP keywordsSEXP, SEXP is_pheno_data_from_FCSSEXP, SEXP keyword_ignore_caseSEXP, SEXP extend_valSEXP, SEXP extend_toSEXP, SEXP channel_ignore_caseSEXP, SEXP leaf_boolSEXP, SEXP include_empty_treeSEXP, SEXP compsSEXP, SEXP transformSEXP, SEXP fcs_file_extensionSEXP, SEXP greedy_matchSEXP, SEXP fcs_parse_argSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -46,9 +46,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< List >::type comps(compsSEXP);
     Rcpp::traits::input_parameter< bool >::type transform(transformSEXP);
     Rcpp::traits::input_parameter< string >::type fcs_file_extension(fcs_file_extensionSEXP);
+    Rcpp::traits::input_parameter< bool >::type greedy_match(greedy_matchSEXP);
     Rcpp::traits::input_parameter< FCS_READ_PARAM >::type fcs_parse_arg(fcs_parse_argSEXP);
     Rcpp::traits::input_parameter< int >::type num_threads(num_threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(parse_workspace(ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, fcs_parse_arg, num_threads));
+    rcpp_result_gen = Rcpp::wrap(parse_workspace(ws, group_id, subset, execute, path, h5_dir, includeGates, additional_keys, additional_sampleID, keywords, is_pheno_data_from_FCS, keyword_ignore_case, extend_val, extend_to, channel_ignore_case, leaf_bool, include_empty_tree, comps, transform, fcs_file_extension, greedy_match, fcs_parse_arg, num_threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -112,7 +113,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_CytoML_open_workspace", (DL_FUNC) &_CytoML_open_workspace, 3},
-    {"_CytoML_parse_workspace", (DL_FUNC) &_CytoML_parse_workspace, 22},
+    {"_CytoML_parse_workspace", (DL_FUNC) &_CytoML_parse_workspace, 23},
     {"_CytoML_get_keywords_by_id", (DL_FUNC) &_CytoML_get_keywords_by_id, 2},
     {"_CytoML_get_keywords_by_name", (DL_FUNC) &_CytoML_get_keywords_by_name, 2},
     {"_CytoML_get_sample_groups", (DL_FUNC) &_CytoML_get_sample_groups, 1},

--- a/src/parseFlowJoWorkspace.cpp
+++ b/src/parseFlowJoWorkspace.cpp
@@ -55,8 +55,9 @@ XPtr<GatingSet> parse_workspace(XPtr<flowJoWorkspace> ws
                                   , bool leaf_bool
 								  , bool include_empty_tree
 								  , List comps
-                  , bool transform
+								  , bool transform
 								  , string fcs_file_extension
+								  , bool greedy_match
 								 , FCS_READ_PARAM fcs_parse_arg
                                  , int num_threads = 1
 )
@@ -78,6 +79,7 @@ XPtr<GatingSet> parse_workspace(XPtr<flowJoWorkspace> ws
   config.compute_leaf_bool_node = leaf_bool;
   config.include_empty_tree = include_empty_tree;
   config.fcs_file_extension = fcs_file_extension;
+  config.greedy_match = greedy_match;
   config.transform = transform;
   
   SEXP nm = subset.names();

--- a/tests/testthat/flowjo2gs_internalTestSuite.R
+++ b/tests/testthat/flowjo2gs_internalTestSuite.R
@@ -407,11 +407,13 @@ test_that("v 10.0.7 - vX 20.0 (PROVIDE/CyTOF) ellipseidGate (fasinh)",{
                , "FCS")
       
       #relax the rules (shouldn't be doing this, just for the sake of testing)
-      capture.output(gs <- flowjo_to_gatingset(ws, name = 1, subset = 3, additional.keys = NULL))
+      # UPDATE: After changes to search_for_fcs, this kind of evasion of $TOT check is not possible
+      # so this test will be disabled
+      # capture.output(gs <- flowjo_to_gatingset(ws, name = 1, subset = 3, additional.keys = NULL))
     
-      gh <- gs[[1]]
-      thisCounts <- gh_pop_compare_stats(gh)[, list(xml.count,openCyto.count, node)]
-      expect_equal(thisCounts[, openCyto.count], thisCounts[, xml.count], tol = 0.04)
+      # gh <- gs[[1]]
+      # thisCounts <- gh_pop_compare_stats(gh)[, list(xml.count,openCyto.count, node)]
+      # expect_equal(thisCounts[, openCyto.count], thisCounts[, xml.count], tol = 0.04)
       
     })
 

--- a/tests/testthat/test-GatingSet2flowJo.R
+++ b/tests/testthat/test-GatingSet2flowJo.R
@@ -179,7 +179,7 @@ test_that("gatingset_to_flowjo: handle special encoding in keywords ",{
   write.flowSet(fs, outDir)
   ws <- open_flowjo_xml(outFile)
   # At this point, a subdirectory should exist with duplicate file
-  expect_error(flowjo_to_gatingset(ws, name = 1), "Duplicated")
+  expect_error(flowjo_to_gatingset(ws, name = 1), "Multiple FCS files match")
   # Use greedy_match to avoid the duplicate
   gs2 <- flowjo_to_gatingset(ws, name = 1, greedy_match = TRUE)
   # stats1 <- gh_pop_compare_stats(gs)

--- a/tests/testthat/test-GatingSet2flowJo.R
+++ b/tests/testthat/test-GatingSet2flowJo.R
@@ -178,7 +178,10 @@ test_that("gatingset_to_flowjo: handle special encoding in keywords ",{
   
   write.flowSet(fs, outDir)
   ws <- open_flowjo_xml(outFile)
-  gs2 <- flowjo_to_gatingset(ws, name = 1)
+  # At this point, a subdirectory should exist with duplicate file
+  expect_error(flowjo_to_gatingset(ws, name = 1), "Duplicated")
+  # Use greedy_match to avoid the duplicate
+  gs2 <- flowjo_to_gatingset(ws, name = 1, greedy_match = TRUE)
   # stats1 <- gh_pop_compare_stats(gs)
   expect_is(gs2, "GatingSet")
 })


### PR DESCRIPTION
You can see https://github.com/RGLab/CytoML/issues/76 for further discussion of the motivations for rewriting the logical flow of `search_for_fcs`. Changes made:

- New matching logic:

1. Gather files first by whether base filename within directory matches sample name
2. If none found, gather files with `$FIL` keyword matching sample name
-- Note, the second commit reduces directory traversals and repeated file access by keeping
track of matches during steps 1 and 2 and ensures `$TOT` matches for any prospective matched file. It also converts the ballooning nested if/else's to switches for (in my opinion) slightly improved readability. If this level of reworking isn't desired, the second commit can just be reverted as the end behavior is the same after the first commit.
3. Attempt to filter down to single matched file.
- If already single file, UID is just sample name. NOTE: this is different from prior behavior where `$TOT` was always automatically appended
- First filter down to those files that match `$TOT`, and if that's not enough, try using the sequence of selected keywords + sampleID
- Only append as much information to the UID as was necessary for the unambiguous match
- If there are still multiple matched files, throw error with message containing all prospective matched full file paths and prompt user to resolve the ambiguity by moving files. NOTE: I kept this case an error because that was its prior behavior, but in this case should we just report a warning and skip the sample?


Testing:
From the main `CytoML` tests, there are two expected failures:

Here, `$TOT` is no longer appended to the sample name because it is not necessary to determine the match
```
test-flowjo2gs.R:107: failure: use additional keywords for guid
sampleNames(gs2[[1]]) not equal to paste(sampleNames(gh), trimws(keyword(gh)[["$TOT"]]), sep = "_").
1/1 mismatches
x[1]: "CytoTrol_CytoTrol_1.fcs"
y[1]: "CytoTrol_CytoTrol_1.fcs_119531"
```
And here is the case I discussed in https://github.com/RGLab/CytoML/issues/76#issuecomment-578343876, which was only succeeding because of inconsistent logic before. Now it hits the new error message pointing out the ambiguously matched files:

```
test-GatingSet2flowJo.R:181: error: gatingset_to_flowjo: handle special encoding in keywords 
Multiple FCS files match sample A01 by filename, event count, and keywords.
Candidates are: 
/tmp/RtmpLSu2d1/s5a01.fcs
/tmp/RtmpLSu2d1/file759152cbdb51/s5a01.fcs
Please move incorrect files out of this directory or its subdirectories or this sample will be excluded.
```
If/when we decide this is good to merge, I can add a commit to update those two tests to reflect the change. I'll also be adding more test cases with problematic datasets that hit each of the subcases. 

@mikejiang, I currently cannot run all of the tests in `flowjo2gs_internalTestSuite.R` because of access to some recently added files. Would you be able to run those tests before/after these commits to see if any new errors arise?
