### PR TITLE
Proposed fix for #130

### DIFF
--- a/R/cytobankExperiment.R
+++ b/R/cytobankExperiment.R
@@ -274,6 +274,7 @@ ce_get_transformations <- function(x, panel_name = NULL){
       {
         T <- sinh(1) * cofactor
         res[[pname]] <- asinhtGml2_trans(T = T, M = 0.43429448190325176, A = 0)#seems that M and A values are constant in cytobank
+        test <- res[[pname]]$transform(cofactor)
       }else if(stype != "Linear")
         stop("Unknown scale type: ", stype)
       


### PR DESCRIPTION
Temporary fix for bug where the last scale co-factor gets applied to all asinh channels. May have something to do with lazy evaluation and 'T' parameter not being set correctly if the function is not called before co-factor is reset. Addresses issue #130. 