### PR TITLE
fix linear transformation parsing bug

### DIFF
--- a/inst/include/CytoML/winFlowJoWorkspace.hpp
+++ b/inst/include/CytoML/winFlowJoWorkspace.hpp
@@ -870,7 +870,7 @@ public:
 				  // and only meaningful for scaling cytolib::ellipsoidGate from 256 back
 				  // minRange=atof(transNode.getProperty("minRange").c_str());to raw
 				  cytolib::EVENT_DATA_TYPE maxRange =
-				    atof(transNode.getProperty("transforms:maxRange").c_str());
+				    atof(transNode.getProperty("maxRange").c_str());
 				  if (maxRange == 0) maxRange = 1;
 				  
 				  std::shared_ptr<cytolib::scaleTrans> curTran(


### PR DESCRIPTION
That bug was introduced when porting some [changes](https://github.com/RGLab/CytoML/commit/ee4f874eeb8a4d75d1f7517c051b192f8e928f8d) from internal repo where we re-factored XML parsing by using pugixml, and its xpath query syntax is slightly different from libxml2  which is the one used by open source repo.(it doesn't take namespace prefix ,i.e. `transforms:maxRange`, and silently failed when received such property name).

that was the root cause of erroneous scaling on FCS-A, SSC_A. (reported by #142).

It took a while to figured it out ,the fix is easy though.

Here is the new parsing results
![image](https://user-images.githubusercontent.com/1385649/185776885-cfbccb23-0b52-4a0b-95a8-65306608523d.png)
