### PR TITLE
Hotfix/update symlink option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.17.0
+Version: 2.18.0
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.16.0
+Version: 2.17.0
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.18.0
+Version: 2.19.0
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.15.2
+Version: 2.15.3
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.15.3
+Version: 2.16.0
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CytoML
 Type: Package
 Title: A GatingML Interface for Cross Platform Cytometry Data Sharing
-Version: 2.19.0
+Version: 2.19.1
 Date: 2016-04-15
 Author: Mike Jiang, Jake Wagner
 Maintainer: Mike Jiang <mike@ozette.com>

--- a/inst/include/CytoML/workspace_type.hpp
+++ b/inst/include/CytoML/workspace_type.hpp
@@ -64,7 +64,7 @@ namespace CytoML
 	{
 		vector<string> paths;
 
-        for(const fs::directory_entry & i: fs::recursive_directory_iterator(fs::path(data_dir), fs::symlink_option::recurse))
+        for(const fs::directory_entry & i: fs::recursive_directory_iterator(fs::path(data_dir), fs::directory_options::follow_directory_symlink))
         {
         	if(i.path().extension().string() == ext)
         		paths.push_back(i.path().string());


### PR DESCRIPTION
filesystem::symlink_option is now deprecated by directory_options in the latest boost library causing bioconductor build error
```
../inst/include/CytoML/workspace_type.hpp:67:101: error: ‘symlink_option’ is not a member of ‘fs’
```
